### PR TITLE
Add Python 3.11 setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment
+.venv/
+venv/
+
+# Distribution / packaging
+.Python
+env/
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Logs
+*.log
+
+# dotenv
+.env
+

--- a/mexc_bot/README.md
+++ b/mexc_bot/README.md
@@ -16,3 +16,19 @@ docker compose up --build -d
 При `USE_TESTNET=true` ордера не отправляются на биржу. Чтобы дополнительно
 сохранять свечи в архив `data/ohlc_archive.csv`, выставьте `ARCHIVE_CSV=true` в
 `.env`.
+
+## Tested with Python 3.11 / 3.10
+
+Библиотека `mexc-sdk-python` в текущей версии не устанавливается под Python 3.12. 
+Рекомендуется использовать Python 3.11 (или 3.10) и отдельное виртуальное окружение. 
+Ниже пример настройки с помощью `pyenv`:
+
+```bash
+pyenv install 3.11.12
+pyenv local 3.11.12
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Dockerfile и `docker-compose.yml` уже используют образ Python 3.11.


### PR DESCRIPTION
## Summary
- document that the project is tested with Python 3.11 and 3.10
- provide example setup instructions using pyenv
- add a `.gitignore` for virtualenvs and temporary files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d5716148832f9048173229b11ca1