### PR TITLE
Fix BingX feed payload and message filter

### DIFF
--- a/mexc_bot/core/feed.py
+++ b/mexc_bot/core/feed.py
@@ -84,13 +84,15 @@ class StreamingDataFeed:
                 try:
                     async with websockets.connect(url) as ws:
                         logger.info(f"Connected to BingX WebSocket for {self.symbol}")
-                        await ws.send(json.dumps({"type": "subscribe", "topic": topic}))
+                        payload = {"event": "subscribe", "topic": topic,
+                                  "params": {"binary": "false"}}
+                        await ws.send(json.dumps(payload))
                         async for raw in ws:
                             msg = json.loads(raw)
                             k = msg.get("data") or msg
                             if not k:
                                 continue
-                            if k.get("event") != "kline" and "c" not in k:
+                            if "c" not in k:        # BingX kline payload
                                 continue
 
                             candle = {


### PR DESCRIPTION
## Summary
- adjust BingX websocket payload
- simplify message filter for BingX kline messages

## Testing
- `python -m py_compile mexc_bot/core/feed.py`
- `pytest -q` *(fails: No module named 'core.trader')*

------
https://chatgpt.com/codex/tasks/task_e_6866661c416c832fa78e81d14e7814d4