### PR TITLE
Switch to SINGLE_SIDE_FEE constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Dockerfile и `docker-compose.yml` уже используют образ Python
 ## Комиссия
 
 Комиссии на вход и выход рассчитываются отдельно.
-При открытии позиции баланс уменьшается на `position_size * COMMISSION_RATE_ENTRY`.
-При закрытии комиссия берётся как `position_size * exit_price * COMMISSION_RATE_EXIT` и
+При открытии позиции баланс уменьшается на `position_size * SINGLE_SIDE_FEE`.
+При закрытии комиссия берётся как `position_size * exit_price * SINGLE_SIDE_FEE` и
 вычитается из расчёта PnL. Оба коэффициента по умолчанию равны `0.00035`,
 что в сумме соответствует прежнему уровню 0.07% за полный круг.
 

--- a/mexc_bot/README.md
+++ b/mexc_bot/README.md
@@ -44,8 +44,8 @@ Dockerfile и `docker-compose.yml` уже используют образ Python
 ## Комиссия
 
 Комиссии на вход и выход рассчитываются отдельно.
-При открытии позиции баланс уменьшается на `position_size * COMMISSION_RATE_ENTRY`.
-При закрытии комиссия берётся как `position_size * exit_price * COMMISSION_RATE_EXIT` и
+При открытии позиции баланс уменьшается на `position_size * SINGLE_SIDE_FEE`.
+При закрытии комиссия берётся как `position_size * exit_price * SINGLE_SIDE_FEE` и
 вычитается из расчёта PnL. Оба коэффициента по умолчанию равны `0.00035`,
 что в сумме соответствует прежнему уровню 0.07% за полный круг.
 

--- a/mexc_bot/core/backtest.py
+++ b/mexc_bot/core/backtest.py
@@ -2,9 +2,10 @@
 from typing import Optional
 import logging
 import pandas as pd
+from .broker import SINGLE_SIDE_FEE
 
-COMMISSION_RATE_ENTRY = 0.00035
-COMMISSION_RATE_EXIT = 0.00035
+COMMISSION_RATE_ENTRY = SINGLE_SIDE_FEE
+COMMISSION_RATE_EXIT = SINGLE_SIDE_FEE
 
 
 def run_backtest(strategy) -> Optional[pd.DataFrame]:
@@ -179,7 +180,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
                     old_value = entry_price * position_size
                     new_value = current['Close'] * additional_size
                     position_size += additional_size
-                    balance -= additional_size * COMMISSION_RATE_ENTRY
+                    balance -= additional_size * SINGLE_SIDE_FEE
                     entry_price = (old_value + new_value) / position_size
                     exit_levels = strategy.calculate_dynamic_exit_levels('SHORT', entry_price, current)
                     stop_loss_price = exit_levels['stop_loss']
@@ -199,7 +200,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
             entry_date = current.name
             stop_loss_price = exit_levels['stop_loss']
             take_profit_price = exit_levels['take_profit']
-            balance -= position_size * COMMISSION_RATE_ENTRY
+            balance -= position_size * SINGLE_SIDE_FEE
             strategy.trade_history.append({
                 'entry_date': current.name,
                 'position': 'LONG',
@@ -226,7 +227,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
             entry_date = current.name
             stop_loss_price = exit_levels['stop_loss']
             take_profit_price = exit_levels['take_profit']
-            balance -= position_size * COMMISSION_RATE_ENTRY
+            balance -= position_size * SINGLE_SIDE_FEE
             strategy.trade_history.append({
                 'entry_date': current.name,
                 'position': 'SHORT',
@@ -267,7 +268,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
         if position == 1 and 'unrealized_pnl_pct' in locals() and unrealized_pnl_pct > 0.12 and position_size > 0:
             partial_size = position_size * 0.4
             partial_pnl = partial_size * ((current['Close'] / entry_price) - 1)
-            commission = partial_size * COMMISSION_RATE_EXIT
+            commission = partial_size * SINGLE_SIDE_FEE
             slippage = partial_size * strategy.slippage_pct / 100
             partial_pnl -= (commission + slippage)
             balance += partial_pnl
@@ -275,7 +276,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
         if position == -1 and 'unrealized_pnl_pct' in locals() and unrealized_pnl_pct > 0.12 and position_size > 0:
             partial_size = position_size * 0.4
             partial_pnl = partial_size * (1 - (current['Close'] / entry_price))
-            commission = partial_size * COMMISSION_RATE_EXIT
+            commission = partial_size * SINGLE_SIDE_FEE
             slippage = partial_size * strategy.slippage_pct / 100
             partial_pnl -= (commission + slippage)
             balance += partial_pnl
@@ -292,7 +293,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
             old_value = entry_price * position_size
             new_value = current['Close'] * additional_size
             position_size += additional_size
-            balance -= additional_size * COMMISSION_RATE_ENTRY
+            balance -= additional_size * SINGLE_SIDE_FEE
             entry_price = (old_value + new_value) / position_size
             exit_levels = strategy.calculate_dynamic_exit_levels('LONG', entry_price, current)
             stop_loss_price = exit_levels['stop_loss']

--- a/mexc_bot/core/balanced_strategy_base.py
+++ b/mexc_bot/core/balanced_strategy_base.py
@@ -22,11 +22,11 @@ from .plots import (
     plot_equity_curve as plot_equity_curve_func,
     plot_regime_performance as plot_regime_performance_func,
 )
+from .broker import SINGLE_SIDE_FEE
 
 # Магические числа
-COMMISSION_RATE_ENTRY = 0.00035  # 0.035% комиссия при входе
-# Комиссия при закрытии позиции. Начисляется один раз в \_close_position
-COMMISSION_RATE_EXIT = 0.00035   # 0.035% комиссия при выходе
+COMMISSION_RATE_ENTRY = SINGLE_SIDE_FEE  # 0.035% комиссия при входе
+# SINGLE_SIDE_FEE применяем как ставку комиссии на выход
 SLIPPAGE_PCT = 0.05       # 0.05% по умолчанию
 MIN_BALANCE = 1000
 MIN_POSITION = 100
@@ -1724,7 +1724,7 @@ class BalancedAdaptiveStrategy:
 
         # Entry commission is already deducted when the position is opened,
         # so here we only account for the exit commission and slippage.
-        commission_exit = position_size * exit_price * COMMISSION_RATE_EXIT
+        commission = position_size * exit_price * SINGLE_SIDE_FEE
         slippage = position_size * exit_price * (self.slippage_pct / 100)
 
         if position_type == 'LONG':
@@ -1732,7 +1732,7 @@ class BalancedAdaptiveStrategy:
         else:
             gross_pnl = (entry_price - exit_price) * position_size
 
-        net_pnl = gross_pnl - commission_exit - slippage
+        net_pnl = gross_pnl - commission - slippage
         return net_pnl
 
 

--- a/mexc_bot/core/broker.py
+++ b/mexc_bot/core/broker.py
@@ -7,14 +7,18 @@ import httpx
 from loguru import logger
 from dotenv import load_dotenv
 
+
 load_dotenv()
+
+# Unified commission rate applied per side
+SINGLE_SIDE_FEE = 0.00035
 
 
 class BaseBroker:
     """Abstract broker with basic helpers and dry-run support."""
 
-    COMMISSION_RATE_ENTRY = 0.00035
-    COMMISSION_RATE_EXIT = 0.00035
+    COMMISSION_RATE_ENTRY = SINGLE_SIDE_FEE
+    COMMISSION_RATE_EXIT = SINGLE_SIDE_FEE
 
     def __init__(self, testnet: bool = True):
         self.testnet = testnet


### PR DESCRIPTION
## Summary
- import SINGLE_SIDE_FEE from the broker and remove the local exit commission constant
- use SINGLE_SIDE_FEE for commission calculations in strategy and backtest
- document SINGLE_SIDE_FEE in READMEs

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r mexc_bot/requirements.txt` *(fails: No matching distribution found for mexc-sdk-python)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68666be8618c832fbb8a33aabfba3deb