### PR TITLE
Switch to SINGLE_SIDE_FEE

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Dockerfile и `docker-compose.yml` уже используют образ Python
 ## Комиссия
 
 Комиссии на вход и выход рассчитываются отдельно.
-При открытии позиции баланс уменьшается на `position_size * COMMISSION_RATE_ENTRY`.
-При закрытии комиссия берётся как `position_size * exit_price * COMMISSION_RATE_EXIT` и
+При открытии позиции баланс уменьшается на `position_size * SINGLE_SIDE_FEE`.
+При закрытии комиссия берётся как `position_size * exit_price * SINGLE_SIDE_FEE` и
 вычитается из расчёта PnL. Оба коэффициента по умолчанию равны `0.00035`,
 что в сумме соответствует прежнему уровню 0.07% за полный круг.
-Значения задаются в `mexc_bot.core.constants` и используются в стратегии и при бэктестах.
+Значение комиссии задаётся в `mexc_bot.core.broker` и используется в стратегии и при бэктестах.
 
 ## Telegram notifications
 

--- a/mexc_bot/README.md
+++ b/mexc_bot/README.md
@@ -44,11 +44,11 @@ Dockerfile и `docker-compose.yml` уже используют образ Python
 ## Комиссия
 
 Комиссии на вход и выход рассчитываются отдельно.
-При открытии позиции баланс уменьшается на `position_size * COMMISSION_RATE_ENTRY`.
-При закрытии комиссия берётся как `position_size * exit_price * COMMISSION_RATE_EXIT` и
+При открытии позиции баланс уменьшается на `position_size * SINGLE_SIDE_FEE`.
+При закрытии комиссия берётся как `position_size * exit_price * SINGLE_SIDE_FEE` и
 вычитается из расчёта PnL. Оба коэффициента по умолчанию равны `0.00035`,
 что в сумме соответствует прежнему уровню 0.07% за полный круг.
-Значения задаются в `mexc_bot.core.constants` и используются как в стратегии, так
+Значение комиссии задаётся в `mexc_bot.core.broker` и используется как в стратегии, так
 и в модуле `backtest`.
 
 ## Telegram notifications

--- a/mexc_bot/core/backtest.py
+++ b/mexc_bot/core/backtest.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 import pandas as pd
 
-from .constants import COMMISSION_RATE_ENTRY, COMMISSION_RATE_EXIT
+from .broker import SINGLE_SIDE_FEE
 
 
 def run_backtest(strategy) -> Optional[pd.DataFrame]:
@@ -177,7 +177,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
                     old_value = entry_price * position_size
                     new_value = current['Close'] * additional_size
                     position_size += additional_size
-                    balance -= additional_size * COMMISSION_RATE_ENTRY
+                    balance -= additional_size * SINGLE_SIDE_FEE
                     entry_price = (old_value + new_value) / position_size
                     exit_levels = strategy.calculate_dynamic_exit_levels('SHORT', entry_price, current)
                     stop_loss_price = exit_levels['stop_loss']
@@ -197,7 +197,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
             entry_date = current.name
             stop_loss_price = exit_levels['stop_loss']
             take_profit_price = exit_levels['take_profit']
-            balance -= position_size * COMMISSION_RATE_ENTRY
+            balance -= position_size * SINGLE_SIDE_FEE
             strategy.trade_history.append({
                 'entry_date': current.name,
                 'position': 'LONG',
@@ -224,7 +224,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
             entry_date = current.name
             stop_loss_price = exit_levels['stop_loss']
             take_profit_price = exit_levels['take_profit']
-            balance -= position_size * COMMISSION_RATE_ENTRY
+            balance -= position_size * SINGLE_SIDE_FEE
             strategy.trade_history.append({
                 'entry_date': current.name,
                 'position': 'SHORT',
@@ -265,7 +265,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
         if position == 1 and 'unrealized_pnl_pct' in locals() and unrealized_pnl_pct > 0.12 and position_size > 0:
             partial_size = position_size * 0.4
             partial_pnl = partial_size * ((current['Close'] / entry_price) - 1)
-            commission = partial_size * COMMISSION_RATE_EXIT
+            commission = partial_size * SINGLE_SIDE_FEE
             slippage = partial_size * strategy.slippage_pct / 100
             partial_pnl -= (commission + slippage)
             balance += partial_pnl
@@ -273,7 +273,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
         if position == -1 and 'unrealized_pnl_pct' in locals() and unrealized_pnl_pct > 0.12 and position_size > 0:
             partial_size = position_size * 0.4
             partial_pnl = partial_size * (1 - (current['Close'] / entry_price))
-            commission = partial_size * COMMISSION_RATE_EXIT
+            commission = partial_size * SINGLE_SIDE_FEE
             slippage = partial_size * strategy.slippage_pct / 100
             partial_pnl -= (commission + slippage)
             balance += partial_pnl
@@ -290,7 +290,7 @@ def run_backtest(strategy) -> Optional[pd.DataFrame]:
             old_value = entry_price * position_size
             new_value = current['Close'] * additional_size
             position_size += additional_size
-            balance -= additional_size * COMMISSION_RATE_ENTRY
+            balance -= additional_size * SINGLE_SIDE_FEE
             entry_price = (old_value + new_value) / position_size
             exit_levels = strategy.calculate_dynamic_exit_levels('LONG', entry_price, current)
             stop_loss_price = exit_levels['stop_loss']

--- a/mexc_bot/core/balanced_strategy_base.py
+++ b/mexc_bot/core/balanced_strategy_base.py
@@ -21,7 +21,7 @@ from .plots import (
     plot_equity_curve as plot_equity_curve_func,
     plot_regime_performance as plot_regime_performance_func,
 )
-from .constants import COMMISSION_RATE_EXIT
+from .broker import SINGLE_SIDE_FEE
 warnings.filterwarnings('ignore', category=pd.errors.SettingWithCopyWarning)  # (3) Точечная фильтрация
 
 # Магические числа
@@ -1736,7 +1736,7 @@ class BalancedAdaptiveStrategy:
 
         # Entry commission is already deducted when the position is opened,
         # so here we only account for the exit commission and slippage.
-        commission_exit = position_size * exit_price * COMMISSION_RATE_EXIT
+        commission = position_size * exit_price * SINGLE_SIDE_FEE
         slippage = position_size * exit_price * (self.slippage_pct / 100)
 
         if position_type == 'LONG':
@@ -1744,7 +1744,7 @@ class BalancedAdaptiveStrategy:
         else:
             gross_pnl = (entry_price - exit_price) * position_size
 
-        net_pnl = gross_pnl - commission_exit - slippage
+        net_pnl = gross_pnl - commission - slippage
         return net_pnl
 
 

--- a/mexc_bot/core/broker.py
+++ b/mexc_bot/core/broker.py
@@ -7,6 +7,9 @@ import httpx
 from loguru import logger
 from dotenv import load_dotenv
 
+# Default fee rate for a single side of a trade (maker/taker)
+SINGLE_SIDE_FEE = 0.00035
+
 
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- use the fee constant from `core.broker`
- compute commissions with `SINGLE_SIDE_FEE`
- document new constant usage in READMEs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68666f2b868c832f8fb6f544c51468a8