### PR TITLE
Add requests dependency to requirements

### DIFF
--- a/mexc_bot/requirements.txt
+++ b/mexc_bot/requirements.txt
@@ -2,6 +2,7 @@ numpy>=1.26,<2.0
 pandas>=2.2,<3.0
 httpx>=0.27,<1.0
 websockets>=12.0,<13.0
+requests>=2
 tenacity>=8.2,<9.0
 mexc-sdk-python>=1.4,<2.0
 python-dotenv>=1.0,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=2.2
 httpx>=0.27
 websockets>=12
+requests>=2


### PR DESCRIPTION
## Summary
- update root `requirements.txt`
- add `requests>=2` in `mexc_bot/requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pip install -r mexc_bot/requirements.txt` *(fails: `mexc-sdk-python` not found)*
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'core.trader'`)*

------
https://chatgpt.com/codex/tasks/task_e_686678d9b164832fbfa9c920a4e15dbd