### PR TITLE
Add docstring to balanced strategy module

### DIFF
--- a/mexc_bot/core/balanced_strategy_base.py
+++ b/mexc_bot/core/balanced_strategy_base.py
@@ -1,3 +1,10 @@
+"""Core strategy module used for backtesting BTC futures trading logic.
+
+This file contains the ``BalancedAdaptiveStrategy`` class and supporting
+utilities.  It is responsible for running backtests and evaluating strategy
+parameters before deployment in live trading.
+"""
+
 import pandas as pd
 import numpy as np
 


### PR DESCRIPTION
## Summary
- describe BalancedAdaptiveStrategy module purpose at the top of `balanced_strategy_base.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.trader')*


------
https://chatgpt.com/codex/tasks/task_e_686678ee26d4832fa6238fe291036a50