### PR TITLE
Update CI to install dev dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,5 +17,7 @@ jobs:
         python-version: '3.11'
     - name: Install deps
       run: pip install -r requirements.txt
+    - name: Install dev deps
+      run: pip install -r requirements-dev.txt
     - name: Run tests
       run: pytest -q


### PR DESCRIPTION
## Summary
- install dev dependencies in CI using `requirements-dev.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `loguru`)*

------
https://chatgpt.com/codex/tasks/task_e_68667fa1e058832fb0b917575cf55235