### PR TITLE
Drop mexc-sdk-python dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ numpy~=1.26
 httpx~=0.27
 websockets~=12.0
 requests~=2
-mexc-sdk-python~=1.4
 matplotlib~=3.9
 
 # файл сохранён в кодировке UTF-8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ httpx>=0.27,<1.0
 websockets>=12.0,<13.0
 requests>=2
 tenacity>=8.2,<9.0
-mexc-sdk-python>=1.4,<2.0
 python-dotenv>=1.0,<2.0
 loguru>=0.7,<1.0
 python-telegram-bot>=21.0,<22.0


### PR DESCRIPTION
## Summary
- remove `mexc-sdk-python` from both requirement files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686693a77db4832f89aa825ecb9334bb