### PR TITLE
Switch default exchange to BingX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ```bash
 cp .env.example .env
+# для BingX укажите `EXCHANGE=BINGX`
 # заполните реальные ключи
 
 docker compose up --build -d

--- a/mexc_bot/.env
+++ b/mexc_bot/.env
@@ -4,3 +4,4 @@ TELEGRAM_TOKEN=zzzzzzzzz
 DB_URL=sqlite:///data/trades.db           # или postgresql+psycopg2://user:pass@db:5432/mexc
 DEFAULT_SYMBOL=BTCUSDT
 DEFAULT_INTERVAL=15m
+EXCHANGE=BINGX

--- a/mexc_bot/.env.example
+++ b/mexc_bot/.env.example
@@ -7,7 +7,7 @@ BINGX_TESTNET=true        # альтернатива USE_TESTNET для BingX
 # --- BINGX ---
 BINGX_API_KEY=replace_me
 BINGX_API_SECRET=replace_me
-EXCHANGE=MEXC
+EXCHANGE=BINGX
 BINGX_MARGIN_MODE=isolated   # isolated or cross
 BINGX_LEVERAGE=3
 


### PR DESCRIPTION
## Summary
- set EXCHANGE=BINGX in sample env files
- document the EXCHANGE option in the README

## Testing
- `pip install numpy==1.26.4 pandas==2.2.2 httpx==0.27.0 websockets==12.0 requests>=2 tenacity==8.2.3 python-dotenv==1.0.1 loguru==0.7.2 python-telegram-bot==21.0 SQLAlchemy==2.0.29 alembic==1.13.1 uvicorn[standard]==0.30.0 pytest==8.2.2 matplotlib==3.9.0 -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686697a761a8832fb51d87665e58b48b