### PR TITLE
Switch default exchange to BingX

### DIFF
--- a/mexc_bot/.env.example
+++ b/mexc_bot/.env.example
@@ -7,7 +7,7 @@ BINGX_TESTNET=true        # альтернатива USE_TESTNET для BingX
 # --- BINGX ---
 BINGX_API_KEY=replace_me
 BINGX_API_SECRET=replace_me
-EXCHANGE=MEXC
+EXCHANGE=BINGX
 BINGX_MARGIN_MODE=isolated   # isolated or cross
 BINGX_LEVERAGE=3
 

--- a/mexc_bot/core/feed.py
+++ b/mexc_bot/core/feed.py
@@ -23,11 +23,11 @@ class StreamingDataFeed:
     При ARCHIVE_CSV=true каждую свечу добавляет в CSV‑архив.
     """
 
-    def __init__(self, symbol: str, interval: str, max_rows: int = 4000):
+    def __init__(self, symbol: str, interval: str, exchange: str | None = None, max_rows: int = 4000):
         self.symbol, self.interval = symbol.upper(), interval
         self.max_rows = max_rows
         self.df = pd.DataFrame()
-        self.exchange = os.getenv("EXCHANGE", "MEXC").upper()
+        self.exchange = (exchange or os.getenv("EXCHANGE", "MEXC")).upper()
         if self.exchange == "MEXC":
             if WsSpot is None:
                 raise ImportError(

--- a/mexc_bot/run.py
+++ b/mexc_bot/run.py
@@ -1,10 +1,12 @@
-import asyncio, os
+import asyncio
+import os
 from trader import LiveTrader
 
 if __name__ == "__main__":
     asyncio.run(
         LiveTrader(
-            os.getenv("DEFAULT_SYMBOL","BTCUSDT"),
-            os.getenv("DEFAULT_INTERVAL","15m")
+            os.getenv("DEFAULT_SYMBOL", "BTCUSDT"),
+            os.getenv("DEFAULT_INTERVAL", "15m"),
+            exchange=os.getenv("EXCHANGE", "BINGX"),
         ).run()
     )


### PR DESCRIPTION
## Summary
- default environment to BingX in `.env.example`
- expose `exchange` parameter in `LiveTrader` and pass it through
- accept optional exchange in `StreamingDataFeed`
- run bot with exchange from environment in `run.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686698c2f798832fa31f8e5a3929e747