### PR TITLE
Add pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 required_version: "3.5.0"
-default_language_version: python3.11
+default_language_version:
+  python: python3.12
 repos:
   - repo: https://github.com/psf/black
     rev: 25.1.0
@@ -13,8 +14,6 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
-        additional_dependencies:
-          - "-rrequirements.txt"
   - repo: local
     hooks:
       - id: pytest

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ tg_send("Test OK ✅")
 
 ## Pre-commit
 
+Файл `.pre-commit-config.yaml` задаёт основные хуки `black`, `ruff`, `mypy` и `pytest`.
 Для автоматического форматирования кода и запуска статических проверок
-установите `pre-commit` и активируйте хуки:
+установите `pre-commit` и активируйте их:
 
 ```bash
 pip install pre-commit


### PR DESCRIPTION
## Summary
- add pre-commit config with hooks
- explain how to install pre-commit in README

## Testing
- `pre-commit run --files README.md`
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866c545cc80832fad526a24662b085c