### PR TITLE
Add PnL and health commands

### DIFF
--- a/mexc_bot/core/trader.py
+++ b/mexc_bot/core/trader.py
@@ -1,8 +1,6 @@
 """Trading helpers used by the CLI entrypoints and tests."""
 
 from __future__ import annotations
-
-import asyncio
 import math
 import os
 from dotenv import load_dotenv
@@ -34,6 +32,12 @@ class LiveTrader:
             initial_balance=float(os.getenv("INITIAL_BALANCE", 1000))
         )
         self.tg = TgNotifier()
+        try:
+            import services.telegram_bot as tgmod
+
+            tgmod.trader = self
+        except Exception:
+            pass
         self.balance = float(os.getenv("INITIAL_BALANCE", 1000))
 
     # ------------------------------------------------ #
@@ -123,4 +127,3 @@ class LiveTrader:
 
 
 __all__ = ["LiveTrader"]
-


### PR DESCRIPTION
## Summary
- extend telegram bot with `/pnl_today` and `/health` commands
- compute today's PnL in DB
- expose trader instance for health command

## Testing
- `pytest -q`
- `ruff check mexc_bot/core/db.py mexc_bot/services/telegram_bot.py mexc_bot/core/trader.py`
- `mypy mexc_bot/core/db.py mexc_bot/services/telegram_bot.py mexc_bot/core/trader.py` *(fails: missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68677b2ea880832f8cbad9dc88489b4c