### PR TITLE
Fix compatibility for LiveTrader import

### DIFF
--- a/mexc_bot/trader.py
+++ b/mexc_bot/trader.py
@@ -1,3 +1,9 @@
-from core.trader import LiveTrader
+"""Compatibility wrapper – imports actual LiveTrader from core.trader."""
+from core.trader import LiveTrader as _CoreLiveTrader
 
 __all__ = ["LiveTrader"]
+
+
+class LiveTrader(_CoreLiveTrader):
+    """Alias for backward compatibility."""
+    pass


### PR DESCRIPTION
## Summary
- restore wrapper file `mexc_bot/trader.py` for backwards compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68677b29ee60832fb6b3d96544736935